### PR TITLE
Fixing an bug when determining where to copy the startup scripts.

### DIFF
--- a/startup.py
+++ b/startup.py
@@ -108,7 +108,7 @@ def scripts_path_for_exec(exec_path):
 
     if exec_info_match:
         exec_info = exec_info_match.groupdict()
-        exec_info["scripts_version"] = exec_info.get("version").replace(".", "")
+        exec_info["scripts_version"] = exec_info.get("version").split(".")[0].ljust(4, "0")
 
         if platform.system() == "Windows":
             path_root = os.path.expandvars("%APPDATA%")


### PR DESCRIPTION
Harmony's scripts folder uses only the major version number for the folder name. Including the minor or patch version doesn't get loaded by Harmony.

Example:
Harmony 17.0 creates:
1700-scripts

Harmony 17.0.1 creates:
1701-scripts

The former works and the latter does not.